### PR TITLE
Fix for completing an order

### DIFF
--- a/data/orders.js
+++ b/data/orders.js
@@ -17,7 +17,7 @@ export function getOrders() {
 }
 
 export function completeCurrentOrder(orderId, paymentTypeId) {
-  return fetchWithResponse(`orders/${orderId}/complete`, {
+  return fetchWithResponse(`orders/${orderId}`, {
     method: 'PUT',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,

--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -24,7 +24,7 @@ export default function Orders() {
           {
             orders.map((order) => (
               <tr key={order.id}>
-                <td>{order.created_date}</td>  {/* Display order date */}
+                <td>{order.created_date}</td> {/* Display order date */}
                 <td>{order.total > 0 ? `$${order.total}` : '$0.00'}</td> {/* Display 0 if total is missing or 0 */}
                 <td>{order.payment_type || 'No payment method'}</td> {/* Display obscured account or fallback */}
               </tr>


### PR DESCRIPTION
## Changes

-Changed request url to reflect the proper API endpoint

## Requests / Responses
**Request**

PUT `/orders/{order.id}` updates order with payment type for completion.

```json
{
    "paymentTypeId": 1
}
```

**Response**

HTTP/1.1 204 NO CONTENT


## Testing

-[ ] Authenticate Client
-[ ] Ensure that the authenticated user has a created payment type and an item in their cart
-[ ] Click complete order from the cart view, add payment type, and complete order.
-[ ] Be routed to the order view and see payment type listed on completed order.
-[ ] check database to see everything matches up



## Related Issues

- Fixes #33