### PR TITLE
can now view all catagories when adding a product.

### DIFF
--- a/components/form-elements/select.js
+++ b/components/form-elements/select.js
@@ -1,15 +1,13 @@
-export function Select({id, refEl, options, title, label, addlClass = "" }) {
+export function Select({id, refEl, options = [], title, label, addlClass = "" }) {
   return (
     <div className="field is-expanded">
-      {label ? <label className="label">{label}</label> : <></>}
+      {label && <label className="label">{label}</label>}
       <div className={`select ${addlClass} is-fullwidth`}>
         <select id={id} ref={refEl}>
           <option value="0">{title}</option>
-          {
-            options.map(option => (
-              <option key={option.id} value={option.id}>{option.name}</option>
-            ))
-          }
+          {options.map(option => (
+            <option key={option.id} value={option.id}>{option.name}</option>
+          ))}
         </select>
       </div>
     </div>

--- a/components/product/form.js
+++ b/components/product/form.js
@@ -5,10 +5,24 @@ import { Textarea, Select, Input } from '../form-elements'
 
 export default function ProductForm({ formEl, saveEvent, title, router }) {
   const [categories, setCategories] = useState([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState(null)
 
   useEffect(() => {
-    getCategories().then(catData => setCategories(catData))
+    getCategories()
+      .then(catData => {
+        setCategories(catData)
+        setIsLoading(false)
+      })
+      .catch(err => {
+        console.error("Failed to fetch categories:", err)
+        setError("Failed to load categories. Please try again later.")
+        setIsLoading(false)
+      })
   }, [])
+
+  if (isLoading) return <div>Loading...</div>
+  if (error) return <div>{error}</div>
 
   return (
     <CardLayout title={title}>
@@ -48,5 +62,3 @@ export default function ProductForm({ formEl, saveEvent, title, router }) {
     </CardLayout>
   )
 }
-
-

--- a/data/products.js
+++ b/data/products.js
@@ -15,7 +15,7 @@ export function getProducts(query=undefined) {
 }
 
 export function getCategories() {
-  return fetchWithResponse('categories', {
+  return fetchWithResponse('productcategories', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`
     }


### PR DESCRIPTION
# Fix TypeError in Select Component and Update Category Fetching

This PR addresses two issues:
1. The "TypeError: Cannot read properties of undefined (reading 'map')" error occurring in the Select component within the ProductForm.
2. Updating the endpoint for fetching categories to correctly display categories when adding a product.

## Changes

- Modified the Select component to safely handle undefined or empty options
- Updated the ProductForm to include loading and error states for category fetching
- Added error handling for the category fetch API call
- Updated the `getCategories` function to use the correct endpoint

## Testing

- [ ]  Run the application and navigate to the product form
- [ ]  Verify that the Select component renders correctly with categories
- [ ]  Confirm that categories are now visible when adding a product
- [ ]  Test the form with network throttling to ensure loading state appears
- [ ]  Temporarily modify the API endpoint to trigger an error and verify error handling
