### PR TITLE
Fix for deleting a single item from cart

### DIFF
--- a/components/order/detail.js
+++ b/components/order/detail.js
@@ -7,13 +7,13 @@ export default function CartDetail({ cart, removeProduct }) {
   return (
     <Table headers={headers} footers={footers}>
       {
-        cart.products?.map(product => {
+        cart.lineitems?.map(lineitem => {
           return (
-            <tr key={product.id}>
-              <td>{product.name}</td>
-              <td>{product.price}</td>
+            <tr key={lineitem.id}>
+              <td>{lineitem.product.name}</td>
+              <td>{lineitem.product.price}</td>
               <td>
-                <span className="icon is-clickable" onClick={() => removeProduct(product.id)}>
+                <span className="icon is-clickable" onClick={() => removeProduct(lineitem.id)}>
                   <i className="fas fa-trash"></i>
                 </span>
               </td>

--- a/data/products.js
+++ b/data/products.js
@@ -42,7 +42,7 @@ export function addProductToOrder(id) {
 }
 
 export function removeProductFromOrder(id) {
-  return fetchWithoutResponse(`products/${id}/remove-from-order`, {
+  return fetchWithoutResponse(`lineitem/${id}`, {
     method: 'DELETE',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`


### PR DESCRIPTION
These changes allow the user to successfully delete an item from their cart while in the cart view.

## Changes

- Changes to fetch request url
- Changes to **cartDetail** component to read "lineitem" instead of product

## Requests / Responses
This changed the previous request of `products/${id}/remove-from-order` to `lineitem/${id}`

**Request**

DELETE `/lineitem/n` removes row "n" from `orderproduct` table


**Response**

HTTP/1.1 204 NO CONTENT


## Testing

1. Be logged in as authenticated user
2. Add a product to the cart
3. Navigate to the cart view
4. Click the trash can icon _(delete button)_
5. The client will re-render the cart details without the deleted item
6. Trust, but verify:  view the network dev panel and see the successful delete request to the api, and view the database table to ensure that the correct item was deleted.


## Related Issues

- Fixes bug ticket # 8